### PR TITLE
Explicit Binary Constraints for CPU chip

### DIFF
--- a/cpu/src/stark.rs
+++ b/cpu/src/stark.rs
@@ -76,10 +76,31 @@ where
             reduce::<AB>(&base, local.read_value_1()),
         );
 
+        // Ensure that all operation selector flags are boolean values.
+        builder.assert_bool(local.opcode_flags.is_bus_op);
+        builder.assert_bool(local.opcode_flags.is_pointer_op);
+        builder.assert_bool(local.opcode_flags.is_load);
+        builder.assert_bool(local.opcode_flags.is_load_u8);
+        builder.assert_bool(local.opcode_flags.is_load_s8);
+        builder.assert_bool(local.opcode_flags.is_store);
+        builder.assert_bool(local.opcode_flags.is_store_u8);
+        builder.assert_bool(local.opcode_flags.is_beq);
+        builder.assert_bool(local.opcode_flags.is_bne);
+        builder.assert_bool(local.opcode_flags.is_jal);
+        builder.assert_bool(local.opcode_flags.is_jalv);
+        builder.assert_bool(local.opcode_flags.is_imm32);
+        builder.assert_bool(local.opcode_flags.is_advice);
+        builder.assert_bool(local.opcode_flags.is_stop);
+        builder.assert_bool(local.opcode_flags.is_loadfp);
+        builder.assert_bool(local.opcode_flags.is_write);
+
+        // Ensure that all immediate operand selector flags are boolean values.
+        builder.assert_bool(local.opcode_flags.is_imm_op);
+        builder.assert_bool(local.opcode_flags.is_left_imm_op);
+
+        // Enforce that at most one operation selector is active (i.e., set to 1) per row.
         let sum_opcode_flags = local.opcode_flags.is_bus_op
             + local.opcode_flags.is_pointer_op
-            + local.opcode_flags.is_imm_op
-            + local.opcode_flags.is_left_imm_op
             + local.opcode_flags.is_load
             + local.opcode_flags.is_load_u8
             + local.opcode_flags.is_load_s8
@@ -94,12 +115,9 @@ where
             + local.opcode_flags.is_stop
             + local.opcode_flags.is_loadfp
             + local.opcode_flags.is_write;
+        builder.assert_bool(sum_opcode_flags);
 
         // "Stop" constraints (to check that program execution was not stopped prematurely)
-        builder.assert_bool(local.opcode_flags.is_stop);
-        builder
-            .when(local.opcode_flags.is_stop)
-            .assert_zero(sum_opcode_flags - local.opcode_flags.is_stop); // All other opcode flags are zero
         builder
             .when_transition()
             .when(local.opcode_flags.is_stop)
@@ -142,23 +160,6 @@ impl CpuChip {
         let is_bus_op = local.opcode_flags.is_bus_op;
         let is_pointer_op = local.opcode_flags.is_pointer_op;
         let is_write = local.opcode_flags.is_write;
-
-        builder.assert_bool(is_load);
-        builder.assert_bool(is_load_u8);
-        builder.assert_bool(is_load_s8);
-        builder.assert_bool(is_store_u8);
-        builder.assert_bool(is_store);
-        builder.assert_bool(is_jal);
-        builder.assert_bool(is_jalv);
-        builder.assert_bool(is_beq);
-        builder.assert_bool(is_bne);
-        builder.assert_bool(is_imm32);
-        builder.assert_bool(is_loadfp);
-        builder.assert_bool(is_imm_op);
-        builder.assert_bool(is_left_imm_op);
-        builder.assert_bool(is_bus_op);
-        builder.assert_bool(is_pointer_op);
-        builder.assert_bool(is_write);
 
         let addr_a = local.fp + local.instruction.operands.a();
         let addr_b = local.fp + local.instruction.operands.b();

--- a/cpu/src/stark.rs
+++ b/cpu/src/stark.rs
@@ -76,8 +76,30 @@ where
             reduce::<AB>(&base, local.read_value_1()),
         );
 
+        let sum_opcode_flags = local.opcode_flags.is_bus_op
+            + local.opcode_flags.is_pointer_op
+            + local.opcode_flags.is_imm_op
+            + local.opcode_flags.is_left_imm_op
+            + local.opcode_flags.is_load
+            + local.opcode_flags.is_load_u8
+            + local.opcode_flags.is_load_s8
+            + local.opcode_flags.is_store
+            + local.opcode_flags.is_store_u8
+            + local.opcode_flags.is_beq
+            + local.opcode_flags.is_bne
+            + local.opcode_flags.is_jal
+            + local.opcode_flags.is_jalv
+            + local.opcode_flags.is_imm32
+            + local.opcode_flags.is_advice
+            + local.opcode_flags.is_stop
+            + local.opcode_flags.is_loadfp
+            + local.opcode_flags.is_write;
+
         // "Stop" constraints (to check that program execution was not stopped prematurely)
         builder.assert_bool(local.opcode_flags.is_stop);
+        builder
+            .when(local.opcode_flags.is_stop)
+            .assert_zero(sum_opcode_flags - local.opcode_flags.is_stop); // All other opcode flags are zero
         builder
             .when_transition()
             .when(local.opcode_flags.is_stop)

--- a/cpu/src/stark.rs
+++ b/cpu/src/stark.rs
@@ -77,7 +77,7 @@ where
         );
 
         // "Stop" constraints (to check that program execution was not stopped prematurely)
-
+        builder.assert_bool(local.opcode_flags.is_stop);
         builder
             .when_transition()
             .when(local.opcode_flags.is_stop)
@@ -120,6 +120,23 @@ impl CpuChip {
         let is_bus_op = local.opcode_flags.is_bus_op;
         let is_pointer_op = local.opcode_flags.is_pointer_op;
         let is_write = local.opcode_flags.is_write;
+
+        builder.assert_bool(is_load);
+        builder.assert_bool(is_load_u8);
+        builder.assert_bool(is_load_s8);
+        builder.assert_bool(is_store_u8);
+        builder.assert_bool(is_store);
+        builder.assert_bool(is_jal);
+        builder.assert_bool(is_jalv);
+        builder.assert_bool(is_beq);
+        builder.assert_bool(is_bne);
+        builder.assert_bool(is_imm32);
+        builder.assert_bool(is_loadfp);
+        builder.assert_bool(is_imm_op);
+        builder.assert_bool(is_left_imm_op);
+        builder.assert_bool(is_bus_op);
+        builder.assert_bool(is_pointer_op);
+        builder.assert_bool(is_write);
 
         let addr_a = local.fp + local.instruction.operands.a();
         let addr_b = local.fp + local.instruction.operands.b();


### PR DESCRIPTION
Close #6
Close #7
Close #8 

- Explicit boolean constraints on binary columns (see also https://github.com/valida-xyz/valida/pull/185)
- Make sure that at most one of the operation selectors can turn on
- When `is_stop` is true, all other opcode flags are constrained to be zero

Those fixes can solve the above issues, although some constraints might be redundant. Additionally, there might be room for optimization in the number of constraints, which is a future to-do.