### PR TITLE
Fix Trace Generation Failure for Non-Zero Initial PC

### DIFF
--- a/basic-api/benches/keccak_bench.rs
+++ b/basic-api/benches/keccak_bench.rs
@@ -17,7 +17,7 @@ use valida_cpu::{MachineWithRegisters, StopInstruction};
 use valida_keccak::KeccakFInstruction;
 use valida_machine::{
     Instruction, InstructionWord, Machine, MachineProof, Operands, ProgramROM, ProverOptions,
-    StarkConfigImpl,
+    StarkConfigImpl, StarkField,
 };
 use valida_program::{MachineWithProgramROM, ProgramTableType};
 
@@ -27,7 +27,7 @@ fn prove_program(
 ) -> BasicMachine<BabyBear> {
     let mut machine = BasicMachine::<Val>::default();
     let rom = ProgramROM::new(program);
-    machine.set_program_rom(rom, program_table_type);
+    machine.set_program_rom(0, rom, program_table_type);
     // Set max trace height to the default on the command line: 2**27.
     machine.set_max_trace_height(2 * 2u32.pow(27));
     machine.set_initial_register_values(valida_cpu::Registers { pc: 0, fp: 0x1000 });

--- a/basic-api/src/commands/common.rs
+++ b/basic-api/src/commands/common.rs
@@ -115,7 +115,7 @@ pub fn prepare_basic_machine(
     let mut machine = BasicMachine::<BabyBear>::default();
     machine.set_segment_number(0); // single machine == segment number 0
     machine.set_max_trace_height(max_trace_height);
-    machine.set_program_rom(code, program_table_type);
+    machine.set_program_rom(initial_register_values.pc, code, program_table_type);
     machine.set_initial_register_values(initial_register_values);
     machine.static_data_mut().load(data, static_data_chip_type);
 

--- a/basic-api/src/commands/interactive.rs
+++ b/basic-api/src/commands/interactive.rs
@@ -9,7 +9,7 @@ use crate::{
     ValidaSegmentBootData,
 };
 
-use valida_cpu::{MachineWithCpuChip, Registers};
+use valida_cpu::{MachineWithCpuChip, MachineWithRegisters, Registers};
 use valida_machine::{
     AdviceProvider, AdviceProviderWithDefault, Machine, MemoryBackendTrait, RunningMachine,
     StoppingFlag, StorageBackendTrait, StorageBackendType, ValidaMemoryBackend,
@@ -93,7 +93,11 @@ impl<'a> Context<'a> {
         let reg = self.state_.machine.get_registers().expect("Unexpectedly found no segments in MultiSegmentBasicMachine during interactive execution.");
         let (pc, fp) = (reg.pc, reg.fp);
 
-        let instruction = self.state_.machine.program_rom().get_instruction(pc);
+        let instruction = self
+            .state_
+            .machine
+            .program_rom()
+            .get_instruction(pc, self.state_.machine.initial_register_values().pc);
         println!("{:4} : {:?}", pc, instruction.to_string());
 
         // check if fp is changed
@@ -179,6 +183,8 @@ pub fn last_frame(context: &mut Context) -> String {
 }
 
 pub fn list_instrs(print_size_arg: Option<&String>, context: &mut Context) -> String {
+    let init_reg = context.state_.machine.initial_register_values();
+    let init_pc = init_reg.pc;
     let reg = context.state_.machine.get_registers().expect(
         "Unexpectedly found no segments in MultiSegmentBasicMachine during interactive execution.",
     );
@@ -198,7 +204,7 @@ pub fn list_instrs(print_size_arg: Option<&String>, context: &mut Context) -> St
         if cur_pc >= total_size as u32 {
             break;
         }
-        let instruction = program_rom.get_instruction(cur_pc);
+        let instruction = program_rom.get_instruction(cur_pc, init_pc);
         formatted.push_str(format!("{:4} : {:?}\n", cur_pc, instruction.to_string()).as_str());
     }
     formatted

--- a/basic-api/src/instance_data/mod.rs
+++ b/basic-api/src/instance_data/mod.rs
@@ -39,7 +39,7 @@ impl<F: PrimeField32> MachineInstanceData<F> for ValidaInstanceData {
                 debug_assert!(segment_public_traces.is_empty());
                 // program ROM chip
                 segment_public_traces[1] = self.rom.as_ref().map(|rom| {
-                    let (trace, log) = rom_to_table(rom, verbose[1]);
+                    let (trace, log) = rom_to_table(self.pc_init as usize, rom, verbose[1]);
                     if let Some(log) = log {
                         println!("Public trace for ROM chip:");
                         for line in log {
@@ -156,7 +156,7 @@ impl<F: PrimeField32> MachineInstanceData<F> for ValidaSegmentInstanceData {
                     }
                     // program chip
                     1 => self.rom.as_ref().map(|rom| {
-                        let (trace, log) = rom_to_table(rom, verbose[1]);
+                        let (trace, log) = rom_to_table(self.pc_init as usize, rom, verbose[1]);
                         if let Some(log) = log {
                             println!("Public trace for ROM chip:");
                             for line in log {

--- a/basic-api/src/machine/basic.rs
+++ b/basic-api/src/machine/basic.rs
@@ -729,7 +729,11 @@ impl<F: StarkField> Machine<F> for BasicMachine<F> {
         // and set the segment number in the ephemeral memory chip
         self.mem.segment_number = boot_data.segment_number as usize;
         self.set_max_trace_height(boot_data.max_trace_height);
-        self.set_program_rom(boot_data.program_rom, boot_data.program_table_type);
+        self.set_program_rom(
+            boot_data.initial_register_values.pc,
+            boot_data.program_rom,
+            boot_data.program_table_type,
+        );
         self.set_initial_register_values(boot_data.initial_register_values);
         let static_data_chip_type = match boot_data.program_table_type {
             ProgramTableType::Public => StaticDataChipType::Public,
@@ -1571,8 +1575,17 @@ where
         &self.program().table.0.rom
     }
 
-    fn set_program_rom(&mut self, rom: ProgramROM<i32>, table_type: ProgramTableType) {
-        let table = ProgramTable { table_type, rom };
+    fn set_program_rom(
+        &mut self,
+        init_pc: u32,
+        rom: ProgramROM<i32>,
+        table_type: ProgramTableType,
+    ) {
+        let table = ProgramTable {
+            init_pc,
+            table_type,
+            rom,
+        };
         self.program_mut().set_table(MultiLookupTableWrapper(table));
     }
 

--- a/basic-api/src/machine/basic.rs
+++ b/basic-api/src/machine/basic.rs
@@ -770,7 +770,10 @@ impl<F: StarkField> Machine<F> for BasicMachine<F> {
         let mut step_did_stop = StoppingFlag::DidNotStop;
         loop {
             let pc = state.machine.cpu().pc;
-            let instruction = *state.machine.program_rom().get_instruction(pc);
+            let instruction = *state
+                .machine
+                .program_rom()
+                .get_instruction(pc, state.machine.initial_register_values().pc);
 
             metrics.register_instruction(&instruction, state);
 
@@ -1417,7 +1420,10 @@ impl<F: StarkField> Machine<F> for BasicMachine<F> {
     fn step(state: &mut RunningMachine<'_, F, Self>) -> StoppingFlag {
         // Fetch
         let pc = state.machine.cpu().pc;
-        let instruction = state.machine.program_rom().get_instruction(pc);
+        let instruction = state
+            .machine
+            .program_rom()
+            .get_instruction(pc, state.machine.initial_register_values().pc);
         let opcode = instruction.opcode;
         let ops = instruction.operands;
 
@@ -1540,7 +1546,9 @@ impl<F: StarkField> Machine<F> for BasicMachine<F> {
             _ => panic!("Unrecognized opcode: {}, pc = {}", opcode, pc),
         };
         let log = state.machine.log_enabled();
-        state.machine.read_word(pc, log);
+        state
+            .machine
+            .read_word(pc, state.machine.initial_register_values().pc, log);
 
         // A STOP instruction signals the end of the program
         if opcode == <StopInstruction as Instruction<Self, F>>::OPCODE {

--- a/basic-api/src/machine/multi_segment.rs
+++ b/basic-api/src/machine/multi_segment.rs
@@ -508,7 +508,11 @@ impl<F: StarkField> Machine<F> for MultiSegmentBasicMachine<F> {
 
     fn init(&mut self, boot_data: Self::BootData) {
         self.program_file = boot_data.program_file;
-        self.set_program_rom(boot_data.program_rom, boot_data.program_table_type);
+        self.set_program_rom(
+            boot_data.initial_register_values.pc,
+            boot_data.program_rom,
+            boot_data.program_table_type,
+        );
         self.set_initial_register_values(boot_data.initial_register_values);
         self.set_max_trace_height(boot_data.max_trace_height);
         // store static data in multi segment machine until we run it
@@ -1276,8 +1280,17 @@ impl<F: StarkField> MachineWithProgramROM<F> for MultiSegmentBasicMachine<F> {
         &self.program_table.rom
     }
 
-    fn set_program_rom(&mut self, rom: ProgramROM<i32>, table_type: ProgramTableType) {
-        self.program_table = ProgramTable { table_type, rom };
+    fn set_program_rom(
+        &mut self,
+        init_pc: u32,
+        rom: ProgramROM<i32>,
+        table_type: ProgramTableType,
+    ) {
+        self.program_table = ProgramTable {
+            init_pc,
+            table_type,
+            rom,
+        };
     }
 
     fn program_table_type(&self) -> ProgramTableType {

--- a/basic-api/tests/test_interpreter.rs
+++ b/basic-api/tests/test_interpreter.rs
@@ -16,7 +16,7 @@ fn run_program(asm_path: &str, advice: AdviceProvider) -> Vec<u8> {
     machine.set_max_trace_height(65536);
     let asm = read_to_string(asm_path).expect("Failed to read asm");
     let rom = ProgramROM::from_machine_code(&assemble(&asm).unwrap());
-    machine.set_program_rom(rom, valida_program::ProgramTableType::Public);
+    machine.set_program_rom(0, rom, valida_program::ProgramTableType::Public);
     let fp_init = 16777216; // default stack height
     machine.set_initial_register_values(valida_cpu::Registers { pc: 0, fp: fp_init });
 

--- a/basic-api/tests/test_prover.rs
+++ b/basic-api/tests/test_prover.rs
@@ -845,7 +845,7 @@ fn multi_segment_prove_program(
     // program, so this is customized for each program/test.
     machine.set_max_trace_height(max_trace_height);
     let rom = ProgramROM::new(program);
-    machine.set_program_rom(rom, program_table_type);
+    machine.set_program_rom(0, rom, program_table_type);
     machine.set_initial_register_values(valida_cpu::Registers { pc: 0, fp: 0x1000 });
 
     let mut runtime = ValidaRuntime::default_for_field::<BabyBear>();
@@ -885,7 +885,7 @@ fn prove_program(
     machine.set_segment_number(0);
     machine.set_max_trace_height(65536);
     let rom = ProgramROM::new(program);
-    machine.set_program_rom(rom, program_table_type);
+    machine.set_program_rom(0, rom, program_table_type);
     machine.set_initial_register_values(valida_cpu::Registers { pc: 0, fp: 0x1000 });
 
     let mut runtime = ValidaRuntime::default_for_field::<BabyBear>();

--- a/basic-api/tests/test_prover.rs
+++ b/basic-api/tests/test_prover.rs
@@ -878,6 +878,7 @@ fn multi_segment_prove_program(
 }
 
 fn prove_program(
+    init_pc: u32,
     program: Vec<InstructionWord<i32>>,
     program_table_type: ProgramTableType,
 ) -> (BasicMachine<BabyBear>, ValidaMemoryBackend) {
@@ -885,8 +886,11 @@ fn prove_program(
     machine.set_segment_number(0);
     machine.set_max_trace_height(65536);
     let rom = ProgramROM::new(program);
-    machine.set_program_rom(0, rom, program_table_type);
-    machine.set_initial_register_values(valida_cpu::Registers { pc: 0, fp: 0x1000 });
+    machine.set_program_rom(init_pc, rom, program_table_type);
+    machine.set_initial_register_values(valida_cpu::Registers {
+        pc: init_pc,
+        fp: 0x1000,
+    });
 
     let mut runtime = ValidaRuntime::default_for_field::<BabyBear>();
     let mut state = machine.start(&mut runtime);
@@ -960,7 +964,7 @@ fn expected_div_memory_state(memory_backend: &ValidaMemoryBackend) {
 #[test]
 fn prove_div() {
     let program = div_program::<BabyBear>();
-    let (_machine, memory_backend) = prove_program(program, ProgramTableType::Public);
+    let (_machine, memory_backend) = prove_program(0, program, ProgramTableType::Public);
     expected_div_memory_state(&memory_backend);
 }
 
@@ -1046,7 +1050,14 @@ fn expected_sdiv_memory_state(memory_backend: &ValidaMemoryBackend) {
 #[test]
 fn prove_sdiv() {
     let program = sdiv_program::<BabyBear>();
-    let (_machine, memory_backend) = prove_program(program, ProgramTableType::Public);
+    let (_machine, memory_backend) = prove_program(0, program, ProgramTableType::Public);
+    expected_sdiv_memory_state(&memory_backend);
+}
+
+#[test]
+fn prove_sdiv_with_nonzero_initial_pc() {
+    let program = sdiv_program::<BabyBear>();
+    let (_machine, memory_backend) = prove_program(1234, program, ProgramTableType::Public);
     expected_sdiv_memory_state(&memory_backend);
 }
 
@@ -1102,7 +1113,7 @@ fn prove_multi_segment_single_byte_instrs() {
 #[test]
 fn prove_single_byte_instrs() {
     let program = single_byte_program::<BabyBear>();
-    let (_machine, memory_backend) = prove_program(program, ProgramTableType::Public);
+    let (_machine, memory_backend) = prove_program(0, program, ProgramTableType::Public);
     expected_single_byte_memory_state(&memory_backend);
 }
 
@@ -1117,7 +1128,7 @@ fn expected_fibonacci_memory_state(memory_backend: &ValidaMemoryBackend) {
 fn prove_fibonacci() {
     let program = fib_program::<BabyBear>();
 
-    let (machine, memory_backend) = prove_program(program, ProgramTableType::Public);
+    let (machine, memory_backend) = prove_program(0, program, ProgramTableType::Public);
 
     assert_eq!(machine.cpu().clock, 192);
     assert_eq!(machine.cpu().operations.len(), 192);
@@ -1130,7 +1141,7 @@ fn prove_fibonacci() {
 fn prove_fibonacci_circuit_specific() {
     let program = fib_program::<BabyBear>();
 
-    let (machine, memory_backend) = prove_program(program, ProgramTableType::Preprocessed);
+    let (machine, memory_backend) = prove_program(0, program, ProgramTableType::Preprocessed);
 
     assert_eq!(machine.cpu().clock, 192);
     assert_eq!(machine.cpu().operations.len(), 192);
@@ -1171,7 +1182,7 @@ fn expected_add_with_overflow_memory_state(memory_backend: &ValidaMemoryBackend)
 fn prove_add_with_overflow() {
     let program = add_with_overflow_program::<BabyBear>();
 
-    let (_machine, memory_backend) = prove_program(program, ProgramTableType::Public);
+    let (_machine, memory_backend) = prove_program(0, program, ProgramTableType::Public);
 
     expected_add_with_overflow_memory_state(&memory_backend);
 }
@@ -1203,7 +1214,7 @@ fn expected_sub_with_overflow_memory_state(memory_backend: &ValidaMemoryBackend)
 fn prove_sub_with_overflow() {
     let program = sub_with_overflow_program::<BabyBear>();
 
-    let (_machine, memory_backend) = prove_program(program, ProgramTableType::Public);
+    let (_machine, memory_backend) = prove_program(0, program, ProgramTableType::Public);
 
     expected_sub_with_overflow_memory_state(&memory_backend);
 }
@@ -1235,7 +1246,7 @@ fn expected_sub_with_borrow_propagation_memory_state(memory_backend: &ValidaMemo
 fn prove_sub_with_borrow_propagation() {
     let program = sub_with_borrow_propagation_program::<BabyBear>();
 
-    let (_machine, memory_backend) = prove_program(program, ProgramTableType::Public);
+    let (_machine, memory_backend) = prove_program(0, program, ProgramTableType::Public);
 
     expected_sub_with_borrow_propagation_memory_state(&memory_backend);
 }
@@ -1260,7 +1271,7 @@ fn prove_multi_segment_sub_with_borrow_propagation() {
 fn prove_output() {
     let program = output_program::<BabyBear>();
 
-    let (machine, _memory_backend) = prove_program(program, ProgramTableType::Public);
+    let (machine, _memory_backend) = prove_program(0, program, ProgramTableType::Public);
     let clks = &machine.output().clks_log;
     let tape = machine.output_tape();
     assert_eq!(
@@ -1336,7 +1347,7 @@ fn left_imm_ops_expected_memory_state(memory_backend: &ValidaMemoryBackend) {
 fn prove_left_imm_ops() {
     let program = left_imm_ops_program::<BabyBear>();
 
-    let (_machine, memory_backend) = prove_program(program, ProgramTableType::Public);
+    let (_machine, memory_backend) = prove_program(0, program, ProgramTableType::Public);
 
     left_imm_ops_expected_memory_state(&memory_backend);
 }
@@ -1432,7 +1443,7 @@ fn signed_inequality_expected_memory_state(memory_backend: &ValidaMemoryBackend)
 fn prove_signed_inequality() {
     let program = signed_inequality_program::<BabyBear>();
 
-    let (_machine, memory_backend) = prove_program(program, ProgramTableType::Public);
+    let (_machine, memory_backend) = prove_program(0, program, ProgramTableType::Public);
 
     signed_inequality_expected_memory_state(&memory_backend);
 }
@@ -1469,7 +1480,7 @@ fn loadfp_expected_memory_state(memory_backend: &ValidaMemoryBackend) {
 fn prove_loadfp() {
     let program = loadfp_program::<BabyBear>();
 
-    let (_machine, memory_backend) = prove_program(program, ProgramTableType::Public);
+    let (_machine, memory_backend) = prove_program(0, program, ProgramTableType::Public);
 
     loadfp_expected_memory_state(&memory_backend);
 }
@@ -1529,7 +1540,7 @@ fn prove_keccak() {
     let postimage = convert_array(state);
 
     let program = keccak_program::<BabyBear>();
-    let (_machine, memory_backend) = prove_program(program, ProgramTableType::Public);
+    let (_machine, memory_backend) = prove_program(0, program, ProgramTableType::Public);
 
     // CHECK POSTIMAGE
     for i in 0..50 {

--- a/cpu/src/stark.rs
+++ b/cpu/src/stark.rs
@@ -297,7 +297,7 @@ impl CpuChip {
         builder: &mut AB,
         local: &CpuCols<AB::Var>,
         next: &CpuCols<AB::Var>,
-        public: &CpuPublicVector<AB::Var>,
+        _public: &CpuPublicVector<AB::Var>,
         base: &Word<AB::Expr>,
     ) where
         AB: AirBuilder,
@@ -305,7 +305,10 @@ impl CpuChip {
         AB::Expr: Debug,
         AB::Var: Debug,
     {
-        builder.when_first_row().assert_eq(local.pc, public.pc_init);
+        // TODO: Support `builder.when_first_row().assert_eq(local.pc, public.pc_init);`
+        // Currently, the generated trace may become unexpectedly malformed when the initial `pc` is non-zero.
+        // See https://github.com/lita-xyz/valida-vm/issues/9 for details.
+        builder.when_first_row().assert_zero(local.pc);
 
         let bytes_per_instr_expr = AB::Expr::from_canonical_u32(BYTES_PER_INSTR);
         let should_not_increment_pc = local.opcode_flags.is_jal

--- a/cpu/src/stark.rs
+++ b/cpu/src/stark.rs
@@ -297,7 +297,7 @@ impl CpuChip {
         builder: &mut AB,
         local: &CpuCols<AB::Var>,
         next: &CpuCols<AB::Var>,
-        _public: &CpuPublicVector<AB::Var>,
+        public: &CpuPublicVector<AB::Var>,
         base: &Word<AB::Expr>,
     ) where
         AB: AirBuilder,
@@ -305,10 +305,7 @@ impl CpuChip {
         AB::Expr: Debug,
         AB::Var: Debug,
     {
-        // TODO: Support `builder.when_first_row().assert_eq(local.pc, public.pc_init);`
-        // Currently, the generated trace may become unexpectedly malformed when the initial `pc` is non-zero.
-        // See https://github.com/lita-xyz/valida-vm/issues/9 for details.
-        builder.when_first_row().assert_zero(local.pc);
+        builder.when_first_row().assert_eq(local.pc, public.pc_init);
 
         let bytes_per_instr_expr = AB::Expr::from_canonical_u32(BYTES_PER_INSTR);
         let should_not_increment_pc = local.opcode_flags.is_jal

--- a/machine/src/program.rs
+++ b/machine/src/program.rs
@@ -261,9 +261,9 @@ impl<F> ProgramROM<F> {
         Self(instructions)
     }
 
-    pub fn get_instruction(&self, pc: u32) -> &InstructionWord<F> {
+    pub fn get_instruction(&self, pc: u32, offset: u32) -> &InstructionWord<F> {
         debug_assert!(pc < self.0.len() as u32, "PC out of bounds");
-        &self.0[pc as usize]
+        &self.0[(pc - offset) as usize]
     }
 }
 

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -175,6 +175,7 @@ fn instruction_to_row<F: PrimeField32>(
 }
 
 pub fn rom_to_table<F: PrimeField32>(
+    init_pc: usize,
     rom: &ProgramROM<i32>,
     verbose: bool,
 ) -> (RowMajorMatrix<F>, Option<Vec<String>>) {
@@ -184,7 +185,7 @@ pub fn rom_to_table<F: PrimeField32>(
         .0
         .par_iter()
         .enumerate()
-        .map(instruction_to_row)
+        .map(|(i, instr)| instruction_to_row((i + init_pc, instr)))
         .flat_map(|row| row.to_vec())
         .collect::<Vec<_>>();
 
@@ -219,6 +220,7 @@ impl MemoryFootprint for ProgramTableType {
 
 #[derive(Default, Clone)]
 pub struct ProgramTable {
+    pub init_pc: u32,
     pub table_type: ProgramTableType,
     pub rom: ProgramROM<i32>,
 }
@@ -247,7 +249,7 @@ impl<F: PrimeField32> LookupTable<F> for ProgramTable {
     }
 
     fn lookup_matrix(&self, verbose: bool) -> (RowMajorMatrix<F>, Option<Vec<String>>) {
-        rom_to_table(&self.rom, verbose)
+        rom_to_table(self.init_pc as usize, &self.rom, verbose)
     }
 
     fn width(&self) -> usize {
@@ -263,7 +265,7 @@ pub type ProgramChip<F> = LookupChip<MultiLookupTableWrapper<ProgramTable>, F>;
 
 pub trait MachineWithProgramROM<F: Field>: Machine<F> {
     fn program_rom(&self) -> &ProgramROM<i32>;
-    fn set_program_rom(&mut self, rom: ProgramROM<i32>, table_type: ProgramTableType);
+    fn set_program_rom(&mut self, pc_init: u32, rom: ProgramROM<i32>, table_type: ProgramTableType);
 
     fn program_table_type(&self) -> ProgramTableType;
 }

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -273,7 +273,7 @@ pub trait MachineWithProgramChip<F: PrimeField32>: Machine<F> + MachineWithProgr
 
     fn program_mut(&mut self) -> &mut ProgramChip<F>;
 
-    fn read_word(&mut self, index: u32, log: bool);
+    fn read_word(&mut self, index: u32, offset: u32, log: bool);
 }
 
 impl<F, M> MachineWithProgramChip<F> for M
@@ -288,9 +288,9 @@ where
         self.lookup_chip_mut()
     }
 
-    fn read_word(&mut self, index: u32, log: bool) {
+    fn read_word(&mut self, index: u32, offset: u32, log: bool) {
         if log {
-            let instruction = self.program().table.0.rom.get_instruction(index);
+            let instruction = self.program().table.0.rom.get_instruction(index, offset);
             self.vector_lookup(instruction_to_row((index as usize, instruction)), log);
         }
     }


### PR DESCRIPTION
Close #9 

- This PR fixes `get_instruction` and  `rom_to_table` to consider the initial pc as the offset. Accordingly, this PR also introduces the following modifications:
  
  - Add `init_pc` to the field of the `ProgramTable`, which calls `rom_to_table`
  - Modify `set_program_rom`, which generates `ProgramTable`, to add the initial pc as the argument
  - Add one unit test with non-zero initial pc