### PR TITLE
Enforce `STOP` as the final instruction

### DIFF
--- a/cpu/src/stark.rs
+++ b/cpu/src/stark.rs
@@ -7,7 +7,7 @@ use valida_machine::{Word, MEMORY_CELL_BYTES};
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::{AbstractField, PrimeField};
 use p3_matrix::MatrixRowSlices;
-use valida_opcodes::BYTES_PER_INSTR;
+use valida_opcodes::{Opcode, BYTES_PER_INSTR};
 
 impl<F> BaseAir<F> for CpuChip {
     fn width(&self) -> usize {
@@ -77,7 +77,14 @@ where
         );
 
         // "Stop" constraints (to check that program execution was not stopped prematurely)
-
+        builder
+            .when_last_row()
+            .when_ne(local.is_real, AB::Expr::zero())
+            .assert_one(local.opcode_flags.is_stop);
+        builder
+            .when_transition()
+            .when_ne(next.is_real, AB::Expr::one())
+            .assert_one(local.opcode_flags.is_stop);
         builder
             .when_transition()
             .when(local.opcode_flags.is_stop)

--- a/cpu/src/stark.rs
+++ b/cpu/src/stark.rs
@@ -78,17 +78,13 @@ where
 
         // "Stop" constraints (to check that program execution was not stopped prematurely)
         builder
-            .when_last_row()
-            .when_ne(local.is_real, AB::Expr::zero())
-            .assert_one(local.opcode_flags.is_stop);
-        builder
-            .when_transition()
-            .when_ne(next.is_real, AB::Expr::one())
-            .assert_one(local.opcode_flags.is_stop);
-        builder
             .when_transition()
             .when(local.opcode_flags.is_stop)
             .assert_eq(next.pc, AB::Expr::zero()); // zero, because padded with zeros
+        builder
+            .when_ne(local.is_last_segment, AB::Expr::zero())
+            .when_transition()
+            .assert_eq(local.opcode_flags.is_stop, local.is_real - next.is_real);
         builder
             .when_ne(local.is_last_segment, AB::Expr::zero())
             .when_last_row()


### PR DESCRIPTION
close #16 

This PR adds the following constraint to the CPU chip:

```rust
        builder
            .when_ne(local.is_last_segment, AB::Expr::zero())
            .when_transition()
            .assert_eq(local.opcode_flags.is_stop, local.is_real - next.is_real);
```

This constraint is based on the following observation under the condition that `local.is_last_segment = 1` and `when_transition()`:

- `local.is_real = 1` and `next.is_real = 1`: local row is in the middle of the execution, and `is_stop` should be 0
- `local.is_real = 1` and `next.is_real = 0`: local row is the last instruction of this execution, and `is_stop` should be 1
- `local.is_real = 0` and `next.is_real = 0`: local row is the padded row, and `is_stop` should be 0.
- `local.is_real = 0` and `next.is_real = 1`: it is impossible (see [here](https://github.com/lita-xyz/valida-vm/blob/3d8ebc4714ef068beb9e1edc2d3ebac48169f8aa/cpu/src/stark.rs#L53)).