### PR TITLE
chore: fix build script reliability and compatibility issues

### DIFF
--- a/compile-and-install.sh
+++ b/compile-and-install.sh
@@ -4,19 +4,20 @@ set -e
 
 SYSROOT=/valida-toolchain
 
-if [ $(uname -i) == x86_64 ]; then
-  BUILD_COMMAND="cargo multiarch"
+if [ "$(uname -m)" = "x86_64" ]; then
+  BUILD_COMMAND=(cargo multiarch)
   TARGET_BINARY="./target/cargo-multiarch/x86_64-unknown-linux-gnu/release/valida"
 else
-  BUILD_COMMAND="cargo build --release"
+  BUILD_COMMAND=(cargo build --release)
   TARGET_BINARY="./target/release/valida"
 fi
 
 # Check if DEBUG_ASSERTIONS_ENABLED is set to true
 if [ "$DEBUG_ASSERTIONS_ENABLED" = true ]; then
-    RUSTFLAGS="-C debug-assertions" $BUILD_COMMAND
+    RUSTFLAGS="-C debug-assertions" "${BUILD_COMMAND[@]}"
 else
-    $BUILD_COMMAND
+    "${BUILD_COMMAND[@]}"
 fi
 
+mkdir -p "$SYSROOT/bin"
 install "$TARGET_BINARY" "$SYSROOT/bin/valida"


### PR DESCRIPTION
fixed a couple of issues in the build script:

* replaced `uname -i` with `uname -m`, added quoting, and used `=` instead of `==` for better portability.
* switched `BUILD_COMMAND` to an array and executed it with `"${BUILD_COMMAND[@]}"` so commands with arguments are handled correctly.
* added `mkdir -p "$SYSROOT/bin"` before install to prevent errors when the directory doesn’t exist.

these changes make the script more robust across different environments.
